### PR TITLE
Add log context

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -1,0 +1,37 @@
+package log
+
+import "context"
+
+type MetadataContextKeyType string
+
+const (
+	// MetadataContextKey is a custom context key
+	MetadataContextKey MetadataContextKeyType = "log.metadata.key"
+)
+
+// NewContext create new context that is injected with log.Metadata
+func NewContext(parentCtx context.Context, md Metadata) context.Context {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+
+	if md == nil {
+		md = Metadata{}
+	}
+
+	return context.WithValue(parentCtx, MetadataContextKey, md)
+}
+
+// MetadataFromContext extract log.Metadata from context
+func MetadataFromContext(ctx context.Context) Metadata {
+	if ctx == nil {
+		return Metadata{}
+	}
+
+	ctxVal := ctx.Value(MetadataContextKey)
+	if ctxVal == nil {
+		return Metadata{}
+	}
+
+	return ctxVal.(Metadata)
+}

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -1,0 +1,31 @@
+package log_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raymondwongso/gogox/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewContext(t *testing.T) {
+	t.Run("should not panic when parentCtx is nil", func(t *testing.T) {
+		assert.NotNil(t, log.NewContext(nil, nil))
+	})
+}
+
+func Test_MetadataFromContext(t *testing.T) {
+	t.Run("should not panic when ctx is nil", func(t *testing.T) {
+		assert.NotNil(t, log.MetadataFromContext(nil))
+	})
+
+	t.Run("should not panic when ctx does not contain metadata", func(t *testing.T) {
+		assert.NotNil(t, log.MetadataFromContext(context.Background()))
+	})
+
+	t.Run("should return metadata if exists", func(t *testing.T) {
+		md := log.Metadata{"a": "b"}
+		ctx := log.NewContext(context.Background(), md)
+		assert.Equal(t, md, log.MetadataFromContext(ctx))
+	})
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,7 +1,5 @@
 package log
 
-import "golang.org/x/exp/maps"
-
 // Logger defines generic interface for all logger.
 type Logger interface {
 	Trace(msg string, args ...interface{})
@@ -18,15 +16,4 @@ type Logger interface {
 	Fatalw(msg string, md Metadata, args ...interface{})
 	Panic(msg string, args ...interface{})
 	Panicw(msg string, md Metadata, args ...interface{})
-}
-
-// Metadata defines metadata for logger, which will be included whenever log is written.
-type Metadata map[string]interface{}
-
-// MergeMetadata creates new metadata as a result from merging between md1 and md2.
-func MergeMetadata(md1, md2 Metadata) Metadata {
-	res := Metadata{}
-	maps.Copy(res, md1)
-	maps.Copy(res, md2)
-	return res
 }

--- a/log/metadata.go
+++ b/log/metadata.go
@@ -1,0 +1,14 @@
+package log
+
+import "golang.org/x/exp/maps"
+
+// Metadata defines metadata for logger, which will be included whenever log is written.
+type Metadata map[string]interface{}
+
+// MergeMetadata creates new metadata as a result from merging between md1 and md2.
+func MergeMetadata(md1, md2 Metadata) Metadata {
+	res := Metadata{}
+	maps.Copy(res, md1)
+	maps.Copy(res, md2)
+	return res
+}


### PR DESCRIPTION
Add context usecase for log metadata:
1. NewContext: inject `log.Metadata` into `context`
2. MetadataFromContext: extract `log.Metadata` from `context`