### PR TITLE
fix(errorx): log message in ErrInternal() etc is not showing

### DIFF
--- a/errorx/const.go
+++ b/errorx/const.go
@@ -44,32 +44,20 @@ var DefaultCodeMap = map[codes.Code]string{
 
 // ErrInternal returns generic gogox error with CodeInternal
 func ErrInternal(msg string) *Error {
-	return &Error{
-		Code:    CodeInternal,
-		Message: msg,
-	}
+	return New(CodeInternal, msg)
 }
 
 // ErrNotFound returns generic gogox error with CodeNotFound
 func ErrNotFound(msg string) *Error {
-	return &Error{
-		Code:    CodeNotFound,
-		Message: msg,
-	}
+	return New(CodeNotFound, msg)
 }
 
 // ErrUnauthorized returns generic gogox error with CodeUnauthorized
 func ErrUnauthorized(msg string) *Error {
-	return &Error{
-		Code:    CodeUnauthorized,
-		Message: msg,
-	}
+	return New(CodeUnauthorized, msg)
 }
 
 // ErrInvalidParameter returns generic gogox error with CodeInvalidParameter
 func ErrInvalidParameter(msg string) *Error {
-	return &Error{
-		Code:    CodeInvalidParameter,
-		Message: msg,
-	}
+	return New(CodeInvalidParameter, msg)
 }

--- a/errorx/const_test.go
+++ b/errorx/const_test.go
@@ -1,6 +1,7 @@
 package errorx_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/raymondwongso/gogox/errorx"
@@ -11,22 +12,26 @@ func Test_ErrInternal(t *testing.T) {
 	err := errorx.ErrInternal("some error")
 	assert.Equal(t, "some error", err.Error())
 	assert.Equal(t, errorx.CodeInternal, err.Code)
+	assert.Equal(t, fmt.Sprintf("[%s] %s", err.Code, err.Error()), err.LogError())
 }
 
 func Test_ErrNotFound(t *testing.T) {
 	err := errorx.ErrNotFound("some error")
 	assert.Equal(t, "some error", err.Error())
 	assert.Equal(t, errorx.CodeNotFound, err.Code)
+	assert.Equal(t, fmt.Sprintf("[%s] %s", err.Code, err.Error()), err.LogError())
 }
 
 func Test_ErrUnauthorized(t *testing.T) {
 	err := errorx.ErrUnauthorized("some error")
 	assert.Equal(t, "some error", err.Error())
 	assert.Equal(t, errorx.CodeUnauthorized, err.Code)
+	assert.Equal(t, fmt.Sprintf("[%s] %s", err.Code, err.Error()), err.LogError())
 }
 
 func Test_ErrInvalidParameter(t *testing.T) {
 	err := errorx.ErrInvalidParameter("some error")
 	assert.Equal(t, "some error", err.Error())
 	assert.Equal(t, errorx.CodeInvalidParameter, err.Code)
+	assert.Equal(t, fmt.Sprintf("[%s] %s", err.Code, err.Error()), err.LogError())
 }


### PR DESCRIPTION
there is a problem when using `errorx.ErrInternal()` instead of `errorx.New()`, which is the returned error has no `logError` field value, causing empty log. this PR is to make those log message uniform with the one returned from `New()`